### PR TITLE
feat - add a set of unique values of columns in original dataset 

### DIFF
--- a/src/components/main/index.js
+++ b/src/components/main/index.js
@@ -5,7 +5,7 @@ import { useRef, useEffect, useSpring, useState, useMemo } from "react";
 import {useInterval} from '../../utils/useInterval';
 
 import { ScatterPlot } from '../../plots/scatterPlot';
-import { parseData, parseCsv } from "../../utils/fetchData";
+import { parseData } from "../../utils/fetchData";
 
 export const Main = () => {
   //setup for the scatter plot 

--- a/src/utils/createSet.js
+++ b/src/utils/createSet.js
@@ -1,0 +1,58 @@
+import { parseData } from "./fetchData";
+
+
+/**
+ * @param {Array} inputList 
+ * @returns a set of items of the inputList without undefined / null ,and the spaces on both end of each string is removed
+ */
+function createSet(inputList) {
+  return removeSpaces([...new Set(inputList)].filter(x => x !== undefined && x !== null));
+}
+
+function extractColumn(array, colNum) {
+  return array.map(x => x[colNum]);
+}
+
+function removeSpaces(list) {
+  return list.map(x => x.trim());
+}
+
+/**
+ * 
+ * @param {Array} inputList: a list of string, each string consists of different values, separated by ',' 
+ * @returns a set of all the values
+ */
+function setFromArrayOfStrings(inputList) {
+  let tmpList = [];
+
+  inputList.forEach(item => {
+    if(item) tmpList = tmpList.concat(item.split(","));
+  })
+  return createSet(tmpList);
+}
+
+/******* This function should not be used again, unless need a new csv*********/
+/**
+ * create the set of values of some columns in the raw dataset
+ * including types, studios, tags, contentWarnings, voiceActors
+ */
+function createSetAllData() {
+  parseData((result) => {
+    let rawData = result.data;
+
+    // voice actor: only keep the name, all content after /n is deleted
+    let rawVoiceActors = setFromArrayOfStrings(extractColumn(rawData, 15)); 
+    const rows = [
+      createSet(extractColumn(rawData, 3)), // types
+      createSet(extractColumn(rawData, 5)), // studios
+      setFromArrayOfStrings(extractColumn(rawData, 7)), // tags
+      setFromArrayOfStrings(extractColumn(rawData, 12)), // content warnings
+      rawVoiceActors.map(item => item.split('\n')[0]), // voice actors
+    ]
+
+    let csvContent = "data:text/csv;charset=utf-8," + rows.map(e => e.join(",")).join("\n");
+    var encodedUri = encodeURI(csvContent);
+    
+    window.open(encodedUri);
+  });
+}

--- a/src/utils/fetchData.js
+++ b/src/utils/fetchData.js
@@ -1,6 +1,11 @@
 import Papa from 'papaparse';
 
+/** For the usage of this function, check src/components/main/index.js, which call parseData and add addtional data process*/
 
+/***
+ * function used to download the original Anime dataset (https://www.kaggle.com/vishalmane10/anime-dataset-2022)
+ * @param {function} complete: a callback function that would be called after download success
+ */
 export function parseData(complete) {
   Papa.parse('https://raw.githubusercontent.com/yuxin-miao/silver-doodles/main/Anime.csv', { 
       download: true,
@@ -9,3 +14,14 @@ export function parseData(complete) {
   });
 }
 
+/**
+ * function used to download the set of all data, for this csv creation check src/utils/createSet.js
+ * @param {function} complete: a callback function that would be called after download success 
+ */
+export function parseSetData(complete) {
+  Papa.parse('https://raw.githubusercontent.com/yuxin-miao/silver-doodles/main/setOfData.csv', { 
+      download: true,
+      dynamicTyping: true,
+      complete: complete
+  });
+}


### PR DESCRIPTION
Create a csv file that consists of all the unique values in the column {types, studios, tags, contentWarnings, voiceActors} of original Anime dataset. Each row reprensents one set.
Also Fetch this csv so it could be used directly. 
Because it's quite slow if manipulate the data each time